### PR TITLE
Updating Series Episodes should Put it first on Home

### DIFF
--- a/backend/app/Http/Controllers/ItemController.php
+++ b/backend/app/Http/Controllers/ItemController.php
@@ -38,7 +38,8 @@
     {
       $orderType = $orderBy == 'rating' ? 'asc' : 'desc';
 
-      $item = $this->item->orderBy($orderBy, $orderType)->with('latestEpisode');
+      // $item = $this->item->orderBy($orderBy, $orderType)->with('latestEpisode');
+      $item = $this->item->orderBy('last_updated', $orderType)->with('latestEpisode');
 
       if($type != 'home') {
         $item = $item->where('media_type', $type);
@@ -159,6 +160,7 @@
         'released' => $data['released'],
         'genre' => $data['genre'],
         'created_at' => time(),
+        'last_updated' => time(),
       ]);
 
       if($mediaType == 'tv') {
@@ -181,6 +183,11 @@
 
       if( ! $episode->save()) {
         return response('Server Error', 500);
+      }else{
+      $item = $this->item->where('tmdb_id', $episode->tmdb_id)->first();
+      $item->update([
+      'last_updated' => time(),
+    ]);
       }
     }
 

--- a/backend/app/Item.php
+++ b/backend/app/Item.php
@@ -21,6 +21,7 @@
       'rating',
       'released',
       'created_at',
+      'last_updated',
       'genre',
     ];
 

--- a/backend/database/migrations/2017_08_06_220051_add_item_last_updated_field.php
+++ b/backend/database/migrations/2017_08_06_220051_add_item_last_updated_field.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddItemLastUpdatedField extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->integer('last_updated');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('items', function (Blueprint $table) {
+        	$table->dropColumn('last_updated');
+        });
+    }
+}


### PR DESCRIPTION
Updating series episode details should list it first rather than based on when the series was added to the database. This sort makes more sense as most actively track and watch a select a few series/animes and would like them to be first if the latest episode has been watched. Easier to find and update once the database grows and it gets buried.