### PR TITLE
added migrations to change released_timestamp from timestamp to datetime

### DIFF
--- a/backend/database/migrations/2020_01_09_210708_change_released_timestamp_to_datetime.php
+++ b/backend/database/migrations/2020_01_09_210708_change_released_timestamp_to_datetime.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeReleasedTimestampToDatetime extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->dateTime('released_timestamp')->change();
+        });
+    }
+}


### PR DESCRIPTION
the mysql timestamp column cant support dates before 1970-01-01. Datetime do not have such limitations.