### PR TITLE
Update the last seen attributes from the API

### DIFF
--- a/backend/app/Services/Api/Api.php
+++ b/backend/app/Services/Api/Api.php
@@ -90,7 +90,9 @@ abstract class Api
         ->findBySeasonNumber($this->getSeasonNumber())
         ->first();
 
+      // Mark the episode as seen and update the last_seen_at attribute of the item
       if ($episode) {
+        $found->updateLastSeenAt($found->tmdb_id);
         $episode->update([
           'seen' => true,
         ]);

--- a/backend/tests/Services/Api/ApiTest.php
+++ b/backend/tests/Services/Api/ApiTest.php
@@ -188,4 +188,22 @@ class ApiTest extends TestCase
     $this->assertCount(0, $seenEpisodesBefore);
     $this->assertCount(1, $seenEpisodesAfter);
   }
+
+  public function it_should_update_last_seen_at($fixture)
+  {
+    $this->createTv();
+
+    $api = app($this->apiClass);
+
+    $lastSeenBefore = Item::first()->last_seen_at;
+
+    // sleep for 1 second so that Carbon::now() returns a different date
+    sleep(1);
+
+    $api->handle($this->apiFixtures($fixture));
+
+    $lastSeenAfter = Item::first()->last_seen_at;
+
+    $this->assertNotEquals($lastSeenBefore, $lastSeenAfter);
+  }
 }

--- a/backend/tests/Services/Api/PlexApiTest.php
+++ b/backend/tests/Services/Api/PlexApiTest.php
@@ -70,4 +70,10 @@ class PlexApiTest extends TestCase implements ApiTestInterface
   {
     $this->apiTest->it_should_mark_an_episode_as_seen('plex/episode_seen.json');
   }
+
+  /** @test */
+  public function it_should_update_last_seen_at_of_a_show()
+  {
+    $this->apiTest->it_should_update_last_seen_at('plex/episode_seen.json');
+  }
 }


### PR DESCRIPTION
When using the Plex API, any episodes that are watched are correctly marked as seen but that is not reflected in the last seen ordering in the TV view.

This commit ensures that when an episode is watched, sorting by "Last seen" on the TV page still works.

_Note_: I'll admit that my PHP knowledge is close to non-existent, so I added a unit test to ensure that this works as expected, but I don't know if this commit adheres to PHP best practices. Any feedback is welcome.